### PR TITLE
Fixed 2 bugs in meta-analysis tab

### DIFF
--- a/inst/GLiTRS_Dynameta_app/server.R
+++ b/inst/GLiTRS_Dynameta_app/server.R
@@ -809,7 +809,7 @@ server <- function(input, output) {
       dplyr::filter(Country %in% input$location) %>%
       dplyr::filter(Order %in% input$taxa_order) %>%
       dplyr::filter(Biodiversity_metric %in% input$biodiversity_metric_category) %>%
-      dplyr::filter(Effect_size_type %in% input$Effect_size_type)
+      dplyr::filter(Effect_size_type %in% input$effect_size_category)
     
     # Try to run the model on the currently selected subset of data. If doesn't work, tell user to include more data or view error message.
     base::tryCatch(

--- a/inst/GLiTRS_Dynameta_app/server.R
+++ b/inst/GLiTRS_Dynameta_app/server.R
@@ -842,7 +842,8 @@ server <- function(input, output) {
           dplyr::select(-Treatment_N, -Control_N, -Treatment_mean, -Control_mean, 
                  -Treatment_error, -Control_error, -Control_error_type, -Treatment_error_type, 
                  -Extracted_from, -URL, -Language, -Database, -Life_history_stage, -Control_quantity, -Control_quantity_unit) %>%
-          mutate(Effect_size_type = "LogRR")
+          mutate(Effect_size_type = "LogRR") %>%
+          dplyr::filter(Effect_size_type %in% input$effect_size_category)
         
         # combine in the prior meta-analyses
         prior_custom_model_data <- prior_custom_model_data %>%


### PR DESCRIPTION
input$effect_size_category was incorrectly specified so the filter filtered out all the data - this is now correctly specified

No filter was being applied to GLiTRS data for effect size type, so GLiTRS meta-analysis data that matched the other filters was being shown regardless of whether the user selected Hedges' D or logRR; this also sometimes meant logRR GLiTRS data was being shown on the same axes as prior Hedges' D data. To fix this I added a filter after the effect sizes had been calculated for the GLiTRS data